### PR TITLE
Add AdvantageKit, REV Spark MAX logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ logs/
 
 # Folder that has CTRE Phoenix Sim device config storage
 ctre_sim/
+
+# Build Constants for Git infomation
+src/main/java/frc/robot/BuildConstants.java

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2024.2.1"
-    id 'com.diffplug.spotless' version '6.25.0'
+    id "com.diffplug.spotless" version "6.25.0"
+    id "com.peterabeles.gversion" version "1.10"
 }
 
 sourceCompatibility = JavaVersion.VERSION_17
@@ -45,6 +46,20 @@ wpi.java.debugJni = false
 
 // Set this to true to enable desktop support.
 def includeDesktopSupport = true
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/Mechanical-Advantage/AdvantageKit")
+        credentials {
+            username = "Mechanical-Advantage-Bot"
+            password = "\u0067\u0068\u0070\u005f\u006e\u0056\u0051\u006a\u0055\u004f\u004c\u0061\u0079\u0066\u006e\u0078\u006e\u0037\u0051\u0049\u0054\u0042\u0032\u004c\u004a\u006d\u0055\u0070\u0073\u0031\u006d\u0037\u004c\u005a\u0030\u0076\u0062\u0070\u0063\u0051"
+        }
+    }
+    mavenLocal()
+}
+
+configurations.all {
+    exclude group: "edu.wpi.first.wpilibj"
+}
 
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.
@@ -69,6 +84,10 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+
+    // AdvantageKit
+    def akitJson = new groovy.json.JsonSlurper().parseText(new File(projectDir.getAbsolutePath() + "/vendordeps/AdvantageKit.json").text)
+    annotationProcessor "org.littletonrobotics.akit.junction:junction-autolog:$akitJson.version"
 }
 
 test {
@@ -102,6 +121,24 @@ wpi.java.configureTestTasks(test)
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
 }
+
+task(checkAkitInstall, dependsOn: "classes", type: JavaExec) {
+    mainClass = "org.littletonrobotics.junction.CheckInstall"
+    classpath = sourceSets.main.runtimeClasspath
+}
+compileJava.finalizedBy checkAkitInstall
+
+project.compileJava.dependsOn(createVersionFile)
+gversion {
+    srcDir       = "src/main/java/"
+    classPackage = "frc.robot"
+    className    = "BuildConstants"
+    dateFormat   = "yyyy-MM-dd HH:mm:ss z"
+    timeZone     = "America/Chicago" // Use preferred time zone
+    indent       = "  "
+}
+compileJava.dependsOn 'spotlessApply'
+
 
 spotless {
     java {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -32,12 +32,13 @@ public final class Constants {
     public static final double MAX_ACCELERATION = 2;
   }
 
+  public static final class HardwareConstants {
+    public static final int REV_PDH_ID = 60;
+    public static final int REV_PH_ID = 61;
+  }
+
   public static final class PneumaticsConstants {
-
-    public static final int PneumaticsMoudleID = 61;
-
     public static final class DumpConstants {
-
       // Uppy Downy solonoid
       public static final int OUT = 4;
       public static final int IN = 14;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -19,6 +19,7 @@ import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGReader;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
+import org.littletonrobotics.urcl.URCL;
 import swervelib.parser.SwerveParser;
 
 /**
@@ -55,8 +56,13 @@ public class Robot extends LoggedRobot {
 
     if (isReal()) {
       Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
-      new PowerDistribution(
-          HardwareConstants.REV_PDH_ID, ModuleType.kRev); // Enables power distribution logging
+      PowerDistribution pdh =
+          new PowerDistribution(
+              HardwareConstants.REV_PDH_ID, ModuleType.kRev); // Enables power distribution logging
+      pdh.setSwitchableChannel(true);
+      pdh.close();
+      Logger.registerURCL(URCL.startExternal());
+
     } else {
       setUseTiming(false); // Run as fast as possible
       String logPath =

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -5,12 +5,20 @@
 package frc.robot;
 
 import edu.wpi.first.wpilibj.Filesystem;
-import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.PowerDistribution;
+import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.Constants.HardwareConstants;
 import java.io.File;
 import java.io.IOException;
+import org.littletonrobotics.junction.LogFileUtil;
+import org.littletonrobotics.junction.LoggedRobot;
+import org.littletonrobotics.junction.Logger;
+import org.littletonrobotics.junction.networktables.NT4Publisher;
+import org.littletonrobotics.junction.wpilog.WPILOGReader;
+import org.littletonrobotics.junction.wpilog.WPILOGWriter;
 import swervelib.parser.SwerveParser;
 
 /**
@@ -19,7 +27,7 @@ import swervelib.parser.SwerveParser;
  * the package after creating this project, you must also update the build.gradle file in the
  * project.
  */
-public class Robot extends TimedRobot {
+public class Robot extends LoggedRobot {
 
   private static Robot instance;
   private Command m_autonomousCommand;
@@ -42,6 +50,30 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
+    // Set up logging
+    Logger.recordMetadata("ProjectName", "2024-Robot"); // Set a metadata value
+
+    if (isReal()) {
+      Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
+      new PowerDistribution(
+          HardwareConstants.REV_PDH_ID, ModuleType.kRev); // Enables power distribution logging
+    } else {
+      setUseTiming(false); // Run as fast as possible
+      String logPath =
+          LogFileUtil
+              .findReplayLog(); // Pull the replay log from AdvantageScope (or prompt the user)
+      Logger.setReplaySource(new WPILOGReader(logPath)); // Read replay log
+      Logger.addDataReceiver(
+          new WPILOGWriter(
+              LogFileUtil.addPathSuffix(logPath, "_sim"))); // Save outputs to a new log
+    }
+    Logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
+
+    // Logger.disableDeterministicTimestamps() // See "Deterministic Timestamps" in the
+    // "Understanding Data Flow" page
+    Logger.start(); // Start logging! No more data receivers, replay sources, or metadata values may
+    // be added.
+
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();

--- a/src/main/java/frc/robot/subsystems/Dump.java
+++ b/src/main/java/frc/robot/subsystems/Dump.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.DoubleSolenoid;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants.PneumaticsConstants;
+import frc.robot.Constants.HardwareConstants;
 import frc.robot.Constants.PneumaticsConstants.DumpConstants;
 
 public class Dump extends SubsystemBase {
@@ -16,7 +16,7 @@ public class Dump extends SubsystemBase {
   // The double solenoid that controls the piston
   private DoubleSolenoid doubleSolenoid =
       new DoubleSolenoid(
-          PneumaticsConstants.PneumaticsMoudleID,
+          HardwareConstants.REV_PH_ID,
           PneumaticsModuleType.REVPH,
           DumpConstants.IN,
           DumpConstants.OUT);

--- a/vendordeps/AdvantageKit.json
+++ b/vendordeps/AdvantageKit.json
@@ -1,7 +1,7 @@
 {
     "fileName": "AdvantageKit.json",
     "name": "AdvantageKit",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "uuid": "d820cc26-74e3-11ec-90d6-0242ac120003",
     "frcYear": "2024",
     "mavenUrls": [],
@@ -10,24 +10,24 @@
         {
             "groupId": "org.littletonrobotics.akit.junction",
             "artifactId": "wpilib-shim",
-            "version": "3.0.2"
+            "version": "3.1.0"
         },
         {
             "groupId": "org.littletonrobotics.akit.junction",
             "artifactId": "junction-core",
-            "version": "3.0.2"
+            "version": "3.1.0"
         },
         {
             "groupId": "org.littletonrobotics.akit.conduit",
             "artifactId": "conduit-api",
-            "version": "3.0.2"
+            "version": "3.1.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "org.littletonrobotics.akit.conduit",
             "artifactId": "conduit-wpilibio",
-            "version": "3.0.2",
+            "version": "3.1.0",
             "skipInvalidPlatforms": false,
             "isJar": false,
             "validPlatforms": [

--- a/vendordeps/AdvantageKit.json
+++ b/vendordeps/AdvantageKit.json
@@ -1,0 +1,42 @@
+{
+    "fileName": "AdvantageKit.json",
+    "name": "AdvantageKit",
+    "version": "3.0.2",
+    "uuid": "d820cc26-74e3-11ec-90d6-0242ac120003",
+    "frcYear": "2024",
+    "mavenUrls": [],
+    "jsonUrl": "https://github.com/Mechanical-Advantage/AdvantageKit/releases/latest/download/AdvantageKit.json",
+    "javaDependencies": [
+        {
+            "groupId": "org.littletonrobotics.akit.junction",
+            "artifactId": "wpilib-shim",
+            "version": "3.0.2"
+        },
+        {
+            "groupId": "org.littletonrobotics.akit.junction",
+            "artifactId": "junction-core",
+            "version": "3.0.2"
+        },
+        {
+            "groupId": "org.littletonrobotics.akit.conduit",
+            "artifactId": "conduit-api",
+            "version": "3.0.2"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "org.littletonrobotics.akit.conduit",
+            "artifactId": "conduit-wpilibio",
+            "version": "3.0.2",
+            "skipInvalidPlatforms": false,
+            "isJar": false,
+            "validPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": []
+}

--- a/vendordeps/URCL.json
+++ b/vendordeps/URCL.json
@@ -1,0 +1,65 @@
+{
+    "fileName": "URCL.json",
+    "name": "URCL",
+    "version": "2024.0.1",
+    "frcYear": "2024",
+    "uuid": "84246d17-a797-4d1e-bd9f-c59cd8d2477c",
+    "mavenUrls": [
+        "https://raw.githubusercontent.com/Mechanical-Advantage/URCL/2024.0.1"
+    ],
+    "jsonUrl": "https://raw.githubusercontent.com/Mechanical-Advantage/URCL/maven/URCL.json",
+    "javaDependencies": [
+        {
+            "groupId": "org.littletonrobotics.urcl",
+            "artifactId": "URCL-java",
+            "version": "2024.0.1"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "org.littletonrobotics.urcl",
+            "artifactId": "URCL-driver",
+            "version": "2024.0.1",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "org.littletonrobotics.urcl",
+            "artifactId": "URCL-cpp",
+            "version": "2024.0.1",
+            "libName": "URCL",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "org.littletonrobotics.urcl",
+            "artifactId": "URCL-driver",
+            "version": "2024.0.1",
+            "libName": "URCLDriver",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena",
+                "osxuniversal"
+            ]
+        }
+    ]
+}

--- a/vendordeps/URCL.json
+++ b/vendordeps/URCL.json
@@ -1,25 +1,25 @@
 {
     "fileName": "URCL.json",
     "name": "URCL",
-    "version": "2024.0.1",
+    "version": "2024.1.0",
     "frcYear": "2024",
     "uuid": "84246d17-a797-4d1e-bd9f-c59cd8d2477c",
     "mavenUrls": [
-        "https://raw.githubusercontent.com/Mechanical-Advantage/URCL/2024.0.1"
+        "https://raw.githubusercontent.com/Mechanical-Advantage/URCL/2024.1.0"
     ],
     "jsonUrl": "https://raw.githubusercontent.com/Mechanical-Advantage/URCL/maven/URCL.json",
     "javaDependencies": [
         {
             "groupId": "org.littletonrobotics.urcl",
             "artifactId": "URCL-java",
-            "version": "2024.0.1"
+            "version": "2024.1.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "org.littletonrobotics.urcl",
             "artifactId": "URCL-driver",
-            "version": "2024.0.1",
+            "version": "2024.1.0",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -34,7 +34,7 @@
         {
             "groupId": "org.littletonrobotics.urcl",
             "artifactId": "URCL-cpp",
-            "version": "2024.0.1",
+            "version": "2024.1.0",
             "libName": "URCL",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -49,7 +49,7 @@
         {
             "groupId": "org.littletonrobotics.urcl",
             "artifactId": "URCL-driver",
-            "version": "2024.0.1",
+            "version": "2024.1.0",
             "libName": "URCLDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
## Added

Added [AdvantageKit](https://github.com/Mechanical-Advantage/AdvantageKit) for extra diagnostics and logging for the robot. This will help hook into the [AdvantageScope](https://github.com/Mechanical-Advantage/AdvantageScope) tool for WPILib.

Added a [Git metadata information](https://github.com/Mechanical-Advantage/AdvantageKit/blob/main/docs/VERSION-CONTROL.md) task for each Gradle build, such as the commit SHA, the date of the build, the branch, and if the build was dirty (has changes not committed). _This requires the installation of the Git CLI and be available on the systems or users `PATH`_.

Since REV does not provide an official method of automatically recording data from the Spark Max and Spark Flex, we have provided an unofficial alternative for Java and C++ called [URCL](https://github.com/Mechanical-Advantage/URCL) (**U**nofficial **R**EV-**C**ompatible **L**ogger). This enables live plotting and logging of all devices similar to CTRE's Tuner X plotting feature and Phoenix 6 signal logger.

## Fixed

Fixed issue where formatting failed a build. This will now perform the formatting on all builds, including deploy jobs.

## Changed

Changed around some of the `Constants` of CAN IDs to just point to a new `HardwareConstants` class rather than having subclasses for each "subsystem."