### PR TITLE
Update Gradle Action, create unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This is a basic workflow to build robot code.
-name: Build
+name: Continuous Integration
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch.
@@ -15,8 +15,9 @@ concurrency:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  # This job will build the robot code
   build:
+    name: Build
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -34,12 +35,34 @@ jobs:
 
     # Setup Gradle
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-
-    # Grant execute permission for gradlew
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      uses: gradle/actions/setup-gradle@v3
 
     # Runs a single command using the runners shell
     - name: Compile and run tests on robot code
       run: ./gradlew build
+
+  # This job will run through tests on the robot code
+  test:
+    name: Test
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # This grabs the WPILib docker container
+    container: wpilib/roborio-cross-ubuntu:2024-22.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v4
+
+    # Declares the repository safe and not under dubious ownership.
+    - name: Add repository to git safe directories
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+    
+    # Setup Gradle
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+
+    # Runs a single command using the runners shell
+    - name: Run tests on robot code
+      run: ./gradlew test

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -25,6 +25,6 @@ jobs:
       - uses: actions/checkout@v4
 
       # Runs an action from the Gradle org to validate the Gradle wrapper, see 
-      # https://github.com/gradle/wrapper-validation-action/tree/v1/?tab=readme-ov-file#the-gradle-wrapper-problem-in-open-source
+      # https://github.com/gradle/wrapper-validation-action?tab=readme-ov-file#the-gradle-wrapper-problem-in-open-source
       # for more details as to why this is important.
       - uses: gradle/wrapper-validation-action@v2

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -35,11 +35,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-
-      # Grant execute permission for gradlew
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        uses: gradle/actions/setup-gradle@v3
 
       # Runs our formatter for easier code review
       - name: Run spotlessApply

--- a/src/test/com/oakvillerobotics/frc2024/RobotContainerTest.java
+++ b/src/test/com/oakvillerobotics/frc2024/RobotContainerTest.java
@@ -1,0 +1,8 @@
+package com.oakvillerobotics.frc2024;
+
+public class RobotContainerTest {
+  @test
+  public void createRobotContainer() {
+    new RobotContainer();
+  }
+}


### PR DESCRIPTION
## Added

Added [unit testing](https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/unit-testing.html), this will run tests on the software and report if there are issues with how the robot software is written. This does not replace the need for testing or the use case of a simulated environment such as the [WPILib simulator](https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/introduction.html).

## Changed

Updated the Gradle build action to use [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/tree/main/setup-gradle) rather than the deprecated [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action).

Updated documentation for Actions workflow for [Gradle Wrapper Validation](https://github.com/gradle/wrapper-validation-action) job.
