### PR TITLE
Fix workflow fail on actions push

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+# Set permissions for the workflow
+permissions:
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -24,6 +28,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.PAT }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           fetch-depth: 0
-          persist-credentials: false
 
       # Setup Java 17
       - uses: actions/setup-java@v4

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -4,10 +4,9 @@
 
 package frc.robot.subsystems;
 
+import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkBase.IdleMode;
-
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.MechanismConstants;
 


### PR DESCRIPTION
## Fixed

Fixed issue where the syntax check job would fail due to no access to push to the repository.

> [!CAUTION]
>
> There is a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) used as an [organization secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) that has access to all the repositories. This token can perform actions on behalf of this user. **Only modify this value if you know what you're doing**.