### PR TITLE
Conveyor Belt Motor Direction Change

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -81,7 +81,7 @@ public final class Constants {
     // Conveyor Motors
     public static final int CONVEYOR_MOTOR_1 = 1;
     public static final int CONVEYOR_MOTOR_2 = 2;
-    public static final boolean CONVEYOR_MOTOR_1_INVERTED = false;
+    public static final boolean CONVEYOR_MOTOR_1_INVERTED = true;
     public static final boolean CONVEYOR_MOTOR_2_INVERTED = true;
     public static final double CONVEYOR_MOTOR_SPEED = 0.30;
   }


### PR DESCRIPTION
conveyor belt motors spin in the same direction, making the bot unable to carry the note up the ramp. this simple command change should fix that. Further testing is prefered