### PR TITLE
Fix logic for the flywheels, conveyor

### DIFF
--- a/src/main/java/frc/robot/commands/ConveyorCommand.java
+++ b/src/main/java/frc/robot/commands/ConveyorCommand.java
@@ -24,9 +24,13 @@ public class ConveyorCommand extends Command {
 
   @Override
   public void execute() {
-  if (ConveyorJoystick.getRawButton(5) || ConveyorJoystick.getRawButton(3) || ConveyorJoystick.getRawButton(10)) {
+    if (ConveyorJoystick.getRawButton(5)
+        || ConveyorJoystick.getRawButton(3)
+        || ConveyorJoystick.getRawButton(10)) {
       m_ConveyorSubsystem.intakeConveyor();
-    } else if (ConveyorJoystick.getRawButton(6) || ConveyorJoystick.getRawButton(4) || ConveyorJoystick.getRawButton(9)) {
+    } else if (ConveyorJoystick.getRawButton(6)
+        || ConveyorJoystick.getRawButton(4)
+        || ConveyorJoystick.getRawButton(9)) {
       m_ConveyorSubsystem.reverseConveyor();
       System.out.println("Conveyor Moving in Reverse");
     } else {

--- a/src/main/java/frc/robot/commands/ConveyorCommand.java
+++ b/src/main/java/frc/robot/commands/ConveyorCommand.java
@@ -24,9 +24,9 @@ public class ConveyorCommand extends Command {
 
   @Override
   public void execute() {
-    if (ConveyorJoystick.getRawButton(5 | 3 | 10)) {
+  if (ConveyorJoystick.getRawButton(5) || ConveyorJoystick.getRawButton(3) || ConveyorJoystick.getRawButton(10)) {
       m_ConveyorSubsystem.intakeConveyor();
-    } else if (ConveyorJoystick.getRawButton(6 | 4 | 9)) {
+    } else if (ConveyorJoystick.getRawButton(6) || ConveyorJoystick.getRawButton(4) || ConveyorJoystick.getRawButton(9)) {
       m_ConveyorSubsystem.reverseConveyor();
       System.out.println("Conveyor Moving in Reverse");
     } else {

--- a/src/main/java/frc/robot/commands/FlyWCommand.java
+++ b/src/main/java/frc/robot/commands/FlyWCommand.java
@@ -25,13 +25,13 @@ public class FlyWCommand extends Command {
 
   @Override
   public void execute() {
-    if (FlyWJoystick.getPOV() == (315 | 0 | 45)) {
+  if (FlyWJoystick.getPOV() == 315 || FlyWJoystick.getPOV() == 0 || FlyWJoystick.getPOV() == 45) {
       m_FlyWSubsystem.enableflywheelfull();
-    } else if (FlyWJoystick.getPOV() == (225 | 180 | 135)) {
+    } else if (FlyWJoystick.getPOV() == 225 || FlyWJoystick.getPOV() == 180 || FlyWJoystick.getPOV() == 135) {
       m_FlyWSubsystem.enableflywheellow();
     } else if (FlyWJoystick.getRawButton(12)) {
       m_FlyWSubsystem.enableflywheelreduced();
-    } else if (FlyWJoystick.getRawButton(11 | 7)) {
+    } else if (FlyWJoystick.getRawButton(11) || FlyWJoystick.getRawButton(7)) {
       m_FlyWSubsystem.reverseflywheel();
       System.out.println("Flywheels Moving in Reverse");
     } else {

--- a/src/main/java/frc/robot/commands/FlyWCommand.java
+++ b/src/main/java/frc/robot/commands/FlyWCommand.java
@@ -25,9 +25,11 @@ public class FlyWCommand extends Command {
 
   @Override
   public void execute() {
-  if (FlyWJoystick.getPOV() == 315 || FlyWJoystick.getPOV() == 0 || FlyWJoystick.getPOV() == 45) {
+    if (FlyWJoystick.getPOV() == 315 || FlyWJoystick.getPOV() == 0 || FlyWJoystick.getPOV() == 45) {
       m_FlyWSubsystem.enableflywheelfull();
-    } else if (FlyWJoystick.getPOV() == 225 || FlyWJoystick.getPOV() == 180 || FlyWJoystick.getPOV() == 135) {
+    } else if (FlyWJoystick.getPOV() == 225
+        || FlyWJoystick.getPOV() == 180
+        || FlyWJoystick.getPOV() == 135) {
       m_FlyWSubsystem.enableflywheellow();
     } else if (FlyWJoystick.getRawButton(12)) {
       m_FlyWSubsystem.enableflywheelreduced();


### PR DESCRIPTION
The problem is that the bitwise OR operator (|) is being used where the logical OR operator (||) should be used in the if and else if conditions. To fix this, replace the bitwise OR operator (|) with the logical OR operator (||) in the if and else if conditions.